### PR TITLE
Utility functions for optionally getting API configuration from environment variables

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,11 +2,11 @@
 
 var apiDataUtils = require('./utils/getAPIData.js');
 
-module.exports = function (token, options) {
+module.exports = function(token, options) {
   if (token === undefined || token === "") {
     token = apiDataUtils.getToken();
   }
-  
+
   if (options === undefined) {
     options = {};
   }
@@ -24,21 +24,21 @@ module.exports = function (token, options) {
     host: options.host,
     path: options.path
   };
-  var utils = require ('./utils') (apiData);
+  var utils = require('./utils')(apiData);
 
   return {
-    PACKAGE_VERSION: require ('../package.json').version,
-    arms: require ('./arms') (utils),
-    events: require ('./events') (utils),
-    instruments: require ('./instruments') (utils),
-    users: require ('./users') (utils),
-    metadata: require ('./metadata') (utils),
-    redcapVersion: require ('./redcapVersion') (utils),
-    projects: require ('./projects') (utils),
-    fieldNames: require ('./fieldNames') (utils),
-    files: require ('./files') (utils),
-    records: require ('./records') (utils),
-    reports: require ('./reports') (utils),
-    survey: require ('./survey') (utils)
+    PACKAGE_VERSION: require('../package.json').version,
+    arms: require('./arms')(utils),
+    events: require('./events')(utils),
+    instruments: require('./instruments')(utils),
+    users: require('./users')(utils),
+    metadata: require('./metadata')(utils),
+    redcapVersion: require('./redcapVersion')(utils),
+    projects: require('./projects')(utils),
+    fieldNames: require('./fieldNames')(utils),
+    files: require('./files')(utils),
+    records: require('./records')(utils),
+    reports: require('./reports')(utils),
+    survey: require('./survey')(utils)
   }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,10 @@ module.exports = function (token, options) {
   if (token === undefined || token === "") {
     token = apiDataUtils.getToken();
   }
+  
+  if (options === undefined) {
+    options = {};
+  }
 
   if (options.host === undefined || options.host === "") {
     options.host = apiDataUtils.getHost();

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,20 +1,18 @@
 'use strict';
 
+var apiDataUtils = require('./utils/getAPIData.js');
+
 module.exports = function (token, options) {
   if (token === undefined || token === "") {
-    throw "No API token specified";
+    token = apiDataUtils.getToken();
   }
 
-  if (options === undefined) {
-    throw "No options provided";
+  if (options.host === undefined || options.host === "") {
+    options.host = apiDataUtils.getHost();
   }
 
-  if (options.host === undefined) {
-    throw "Host undefined (options.host)";
-  }
-
-  if (options.path === undefined) {
-    throw "Path undefined (options.path)";
+  if (options.path === undefined || options.path === "") {
+    options.path = apiDataUtils.getPath();
   }
 
   var apiData = {

--- a/lib/utils/getAPIData.js
+++ b/lib/utils/getAPIData.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function getHost () {
+function getHost() {
   var host = process.env.REDCAP_HOST;
 
   if (host === undefined) {
@@ -10,7 +10,7 @@ function getHost () {
   return host;
 }
 
-function getPath () {
+function getPath() {
   var path = process.env.REDCAP_API_PATH;
 
   if (path === undefined) {
@@ -19,7 +19,7 @@ function getPath () {
   return path;
 }
 
-function getToken () {
+function getToken() {
   var token = process.env.REDCAP_API_KEY;
 
   if (token === undefined) {

--- a/lib/utils/getAPIData.js
+++ b/lib/utils/getAPIData.js
@@ -1,0 +1,40 @@
+'use strict';
+
+function getHost () {
+  var host = process.env.REDCAP_HOST;
+
+  if (host === undefined) {
+    throw "REDCAP_HOST missing from environment variables";
+  }
+
+  return host;
+}
+
+function getPath () {
+  var path = process.env.REDCAP_API_PATH;
+
+  if (path === undefined) {
+    return "/api/";
+  }
+  return path;
+}
+
+function getToken () {
+  var token = process.env.REDCAP_API_KEY;
+
+  if (token === undefined) {
+    token = process.env.REDCAP_API_TOKEN;
+  }
+
+  if (token === undefined) {
+    throw "API token missing from environment variables";
+  }
+
+  return token;
+}
+
+module.exports = {
+  getToken: getToken,
+  getHost: getHost,
+  getPath: getPath
+}

--- a/tests/config.js
+++ b/tests/config.js
@@ -1,5 +1,24 @@
 'use strict';
 
+function getHost () {
+  var host = process.env.REDCAP_HOST;
+
+  if (host === undefined) {
+    throw "REDCAP_HOST missing from environment variables";
+  }
+
+  return host;
+}
+
+function getPath () {
+  var path = process.env.REDCAP_API_PATH;
+
+  if (path === undefined) {
+    return "/api/";
+  }
+  return path;
+}
+
 function getToken () {
   var token = process.env.REDCAP_API_KEY;
 
@@ -15,7 +34,7 @@ function getToken () {
 }
 
 module.exports = {
-  host: "redcap.uits.iu.edu",
-  path: "/api/",
+  host: getHost (),
+  path: getPath (),
   token: getToken ()
 }

--- a/tests/config.js
+++ b/tests/config.js
@@ -1,40 +1,17 @@
 'use strict';
 
-function getHost () {
-  var host = process.env.REDCAP_HOST;
+var apiData = require('../lib/utils/getAPIData.js');
 
-  if (host === undefined) {
-    throw "REDCAP_HOST missing from environment variables";
-  }
+var host;
 
-  return host;
-}
-
-function getPath () {
-  var path = process.env.REDCAP_API_PATH;
-
-  if (path === undefined) {
-    return "/api/";
-  }
-  return path;
-}
-
-function getToken () {
-  var token = process.env.REDCAP_API_KEY;
-
-  if (token === undefined) {
-    token = process.env.REDCAP_API_TOKEN;
-  }
-
-  if (token === undefined) {
-    throw "API token missing from environment variables";
-  }
-
-  return token;
+try {
+  host = apiData.getHost();
+} catch {
+  host = "redcap.uits.iu.edu";
 }
 
 module.exports = {
-  host: getHost (),
-  path: getPath (),
-  token: getToken ()
+  host: host,
+  path: apiData.getPath(),
+  token: apiData.getToken()
 }

--- a/tests/config.js
+++ b/tests/config.js
@@ -1,40 +1,17 @@
 'use strict';
 
-function getHost () {
-  var host = process.env.REDCAP_HOST;
+var apiData = require('../lib/utils/getAPIData.js');
 
-  if (host === undefined) {
-    throw "REDCAP_HOST missing from environment variables";
-  }
+var host;
 
-  return host;
-}
-
-function getPath () {
-  var path = process.env.REDCAP_API_PATH;
-
-  if (path === undefined) {
-    return "/api/";
-  }
-  return path;
-}
-
-function getToken () {
-  var token = process.env.REDCAP_API_KEY;
-
-  if (token === undefined) {
-    token = process.env.REDCAP_API_TOKEN;
-  }
-
-  if (token === undefined) {
-    throw "API token missing from environment variables";
-  }
-
-  return token;
+try {
+  host = apiData.getHost();
+} catch {
+  host = "redcap.uits.iu.edu";
 }
 
 module.exports = {
-  host: getHost (),
+  host: host,
   path: getPath (),
   token: getToken ()
 }

--- a/tests/config.js
+++ b/tests/config.js
@@ -12,6 +12,6 @@ try {
 
 module.exports = {
   host: host,
-  path: getPath (),
-  token: getToken ()
+  path: getPath(),
+  token: getToken()
 }


### PR DESCRIPTION
# What was done?
Added functions `getPath()` and `getHost` (analog to `getToken()` defined in `tests/config.js`)

## Breaking Change?
No

# Accepted environment variables
Accepting `$REDCAP_HOST` for host, `$REDCAP_API_PATH` for path and `$REDCAP_API_KEY` as well as `$REDCAP_API_TOKEN` for token.

# Function behaviour in case of environment variable not being found
If no environment variable is set, `getToken()` and `getHost()` will throw an error. For `getPath()` no error is thrown, but rather "/api/" returned as default, because it should be the default api endpoint path used by REDCap.

# Implementation and refactoring details
The utility functions are defined in `lib/utils/apiData.js`

## Refactoring `tests/config.js`
The `tests/config.js` file is refactored to use the exported utility functions from `lib/utils/apiData.js`. However when no host is found, the previous default value "redcap.uits.iu.edu" is preserved to not alter the previous unit test behaviour.

## Refactoring `lib/index.js`
The `lib/index.js` file is refactored such that

1. Token and config can still be provided directly using the `token` and `options` positional arguments
    1. Thus the usage interface is not changed
2. If either of the values for `token`, `host` or `path` are missing, they're attempted to be read from the appropriate environment variables
    1. If no `token` or `host` is found, the errors thrown by the respective function is not caught. Thus the same behaviour of raising errors is preserved 
